### PR TITLE
Quote arguments in the “Running” line

### DIFF
--- a/timer.py
+++ b/timer.py
@@ -10,7 +10,9 @@ def main():
         sys.exit(1)
 
     cmd = sys.argv[1:]
-    print(f"Running: {' '.join(cmd)}")
+       pretty = " ".join(repr(c) for c in cmd)
+    print(f"Running: {pretty}")
+
 
     start = time.time()
     result = subprocess.run(cmd)


### PR DESCRIPTION
Clearer when arguments contain spaces or special characters.