### PR TITLE
Strip newline when counting lines (normalize for Counter)

### DIFF
--- a/log_stats.py
+++ b/log_stats.py
@@ -39,7 +39,8 @@ def main():
         print("\n(No lines to analyze.)")
         return
 
-    counter = Counter(lines)
+      normalized_lines = [l.rstrip("\n") for l in lines]
+    counter = Counter(normalized_lines)
     top = counter.most_common(args.top)
 
     print(f"\nTop {args.top} most common lines:")


### PR DESCRIPTION
Trailing newlines can cause duplicates that look identical.